### PR TITLE
Fix timezone data on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,7 @@ source 'https://rubygems.org' do
 
   gem 'semantic-ui-sass'
   gem 'slim-rails'
+
+  # Timezone info for Windows
+  gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
 end


### PR DESCRIPTION
Hallo,
mir ist grade aufgefallen dass die Tests auf Windows nicht funktionierten, weil die Zeitzonen-Infos fehlen.
Dieser Commit behebt das Problem.